### PR TITLE
Localize input placeholder

### DIFF
--- a/app/helpers/spree/address_search_helper.rb
+++ b/app/helpers/spree/address_search_helper.rb
@@ -3,7 +3,7 @@ module Spree
     def add_search_bar(address_type)
       country_mapping = available_countries.map { |country| [country.iso, country.id] }.to_h
       label = label_tag "#{address_type}_search", Spree.t(:search)
-      text_field = text_field_tag :search, '', class: 'form-control address-search-bar', id: "#{address_type}_search", data: { country_mapping: country_mapping }
+      text_field = text_field_tag :search, '', class: 'form-control address-search-bar', id: "#{address_type}_search", placeholder: Spree.t(:google_maps_placeholder), data: { country_mapping: country_mapping }
       content_tag('p', (label + text_field).html_safe, class: 'form-group')
     end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,3 +6,4 @@ en:
 
   spree:
     google_maps_api_key: 'Google maps api key'
+    google_maps_placeholder: 'Enter a location'


### PR DESCRIPTION
#### What does this PR do?
Adds the ability to change and localize the default placeholder for the Google Maps search input.

#### Any background context you want to provide?
I had to create a decorator to be able to localize the input. The default Google Maps API placeholder reads "Enter a location" and it's not possible to change it from JS afaik.

#### Screenshots (if appropriate)
The following screenshots are in spanish (using es-MX locale from i18n).

**Before**
![deepinscreenshot_select-area_20171024193752](https://user-images.githubusercontent.com/1270156/31974745-e9d366b0-b8f2-11e7-9862-d4f044afc2ba.png)

**After**
![deepinscreenshot_select-area_20171024193854](https://user-images.githubusercontent.com/1270156/31974786-013f60ce-b8f3-11e7-8347-80024557bb30.png)
